### PR TITLE
Updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0 a.o.

### DIFF
--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -7,11 +7,11 @@
         }
     ],
     "requires": {
-        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.6.0",
-        "arm:tools/arm/mdk-toolbox":" ^1.0.0",
-        "arm:tools/kitware/cmake": "^3.28.4",
-        "arm:tools/ninja-build/ninja": "^1.12.0",
-        "arm:compilers/arm/armclang": "^6.22.0",
-        "arm:compilers/arm/arm-none-eabi-gcc": "^13.3.1"
+        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.9.0",
+        "arm:tools/arm/mdk-toolbox":" ^1.1.0",
+        "arm:tools/kitware/cmake": "^3.31.5",
+        "arm:tools/ninja-build/ninja": "^1.12.1",
+        "arm:compilers/arm/armclang": "^6.24.0",
+        "arm:compilers/arm/arm-none-eabi-gcc": "^14.2.1"
     }
 }

--- a/.github/workflows/Test-Examples.yml
+++ b/.github/workflows/Test-Examples.yml
@@ -62,13 +62,13 @@ jobs:
         working-directory: ./
         run: |
           mkdir -p ./CI/Examples/Blinky
-          cp -rf ./BSP/Examples/Blinky/* ./CI/Examples/Blinky/
+          cp -a ./BSP/Examples/Blinky/. ./CI/Examples/Blinky/
 
       - name: Build Blinky AC6
         if: always()
         working-directory: ./CI/Examples/Blinky
         run: |
-          cbuild ./Blinky.csolution.yml --packs --update-rte --packs --toolchain AC6 --rebuild
+          cbuild ./Blinky.csolution.yml --packs --toolchain AC6 --rebuild
 
       - name: Upload Artifact of the Blinky AC6 build
         if: always()

--- a/Examples/Blinky/.cmsis/Blinky+STM32U575I-EV.dbgconf
+++ b/Examples/Blinky/.cmsis/Blinky+STM32U575I-EV.dbgconf
@@ -1,0 +1,130 @@
+// File: STM32U535_545_575_585_59x_5Ax.dbgconf
+// Version: 1.0.0
+// Note: refer to STM32U5 reference manual (RM0456)
+//       refer to STM32U535xx datasheet (DS14217)
+//                STM32U545xx datasheet (DS14216)
+//                STM32U575xx datasheet (DS13737)
+//                STM32U585xx datasheet (DS13086)
+//                STM32U59xxx datasheet (DS13633)
+//                STM32U5Axxx datasheet (DS13543)
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Debug MCU configuration register (DBGMCU_CR)
+//   <o.2>  DBG_STANDBY              <i> Debug standby mode
+//   <o.1>  DBG_STOP                 <i> Debug stop mode
+// </h>
+DbgMCU_CR = 0x00000006;
+
+// <h> Debug MCU APB1L freeze register (DBGMCU_APB1LFZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.22> DBG_I2C2_STOP            <i> I2C2 SMBUS timeout is frozen while CPU is in debug mode
+//   <o.21> DBG_I2C1_STOP            <i> I2C1 SMBUS timeout is frozen while CPU is in debug mode
+//   <o.12> DBG_IWDG_STOP            <i> Debug independent watchdog is frozen while CPU is in debug mode
+//   <o.11> DBG_WWDG_STOP            <i> Debug window watchdog is frozen while CPU is in debug mode
+//   <o.5>  DBG_TIM7_STOP            <i> TIM7 is frozen while CPU is in debug mode
+//   <o.4>  DBG_TIM6_STOP            <i> TIM6 is frozen while CPU is in debug mode
+//   <o.3>  DBG_TIM5_STOP            <i> TIM5 is frozen while CPU is in debug mode
+//   <o.2>  DBG_TIM4_STOP            <i> TIM4 is frozen while CPU is in debug mode
+//   <o.1>  DBG_TIM3_STOP            <i> TIM3 is frozen while CPU is in debug mode
+//   <o.0>  DBG_TIM2_STOP            <i> TIM2 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB1L_Fz = 0x00000000;
+
+// <h> Debug MCU APB1H freeze register (DBGMCU_APB1HFZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.7>  DBG_I2C6_STOP            <i> I2C6 is frozen while CPU is in debug mode
+//                                   <i> Reserved on STM32U535/545/575/585 devices
+//   <o.6>  DBG_I2C5_STOP            <i> I2C5 is frozen while CPU is in debug mode
+//                                   <i> Reserved on STM32U535/545/575/585 devices
+//   <o.5>  DBG_LPTIM2_STOP          <i> LPTIM2 is frozen while CPU is in debug mode
+//   <o.1>  DBG_I2C4_STOP            <i> I2C4 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB1H_Fz = 0x00000000;
+
+// <h> Debug MCU APB2 freeze register (DBGMCU_APB2FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.18> DBG_TIM17_STOP           <i> TIM17 is frozen while CPU is in debug mode
+//   <o.17> DBG_TIM16_STOP           <i> TIM16 is frozen while CPU is in debug mode
+//   <o.16> DBG_TIM15_STOP           <i> TIM15 is frozen while CPU is in debug mode
+//   <o.13> DBG_TIM8_STOP            <i> TIM8 is frozen while CPU is in debug mode
+//   <o.11> DBG_TIM1_STOP            <i> TIM1 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB2_Fz = 0x00000000;
+
+// <h> Debug MCU APB3 freeze register (DBGMCU_APB3FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.30> DBG_RTC_STOP             <i> RTC is frozen while CPU is in debug mode.
+//   <o.19> DBG_LPTIM4_STOP          <i> LPTIM4 is frozen while CPU is in debug mode
+//   <o.18> DBG_LPTIM3_STOP          <i> LPTIM3 is frozen while CPU is in debug mode
+//   <o.17> DBG_LPTIM1_STOP          <i> LPTIM1 is frozen while CPU is in debug mode
+//   <o.10> DBG_I2C3_STOP            <i> I2C3 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB3_Fz = 0x00000000;
+
+// <h> Debug MCU AHB1 freeze register (DBGMCU_AHB1FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.15> DBG_GPDMA15_STOP         <i> GPDMA channel 15 is frozen while CPU is in debug mode
+//   <o.14> DBG_GPDMA14_STOP         <i> GPDMA channel 14 is frozen while CPU is in debug mode
+//   <o.13> DBG_GPDMA13_STOP         <i> GPDMA channel 13 is frozen while CPU is in debug mode
+//   <o.12> DBG_GPDMA12_STOP         <i> GPDMA channel 12 is frozen while CPU is in debug mode
+//   <o.11> DBG_GPDMA11_STOP         <i> GPDMA channel 11 is frozen while CPU is in debug mode
+//   <o.10> DBG_GPDMA10_STOP         <i> GPDMA channel 10 is frozen while CPU is in debug mode
+//   <o.9>  DBG_GPDMA9_STOP          <i> GPDMA channel 9 is frozen while CPU is in debug mode
+//   <o.8>  DBG_GPDMA8_STOP          <i> GPDMA channel 8 is frozen while CPU is in debug mode
+//   <o.7>  DBG_GPDMA7_STOP          <i> GPDMA channel 7 is frozen while CPU is in debug mode
+//   <o.6>  DBG_GPDMA6_STOP          <i> GPDMA channel 6 is frozen while CPU is in debug mode
+//   <o.5>  DBG_GPDMA5_STOP          <i> GPDMA channel 5 is frozen while CPU is in debug mode
+//   <o.4>  DBG_GPDMA4_STOP          <i> GPDMA channel 4 is frozen while CPU is in debug mode
+//   <o.3>  DBG_GPDMA3_STOP          <i> GPDMA channel 3 is frozen while CPU is in debug mode
+//   <o.2>  DBG_GPDMA2_STOP          <i> GPDMA channel 2 is frozen while CPU is in debug mode
+//   <o.1>  DBG_GPDMA1_STOP          <i> GPDMA channel 1 is frozen while CPU is in debug mode
+//   <o.0>  DBG_GPDMA0_STOP          <i> GPDMA channel 0 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_AHB1_Fz = 0x00000000;
+
+// <h> Debug MCU AHB3 freeze register (DBGMCU_AHB3FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.3>  DBG_LPDMA3_STOP          <i> LPDMA channel 3 is frozen while CPU is in debug mode
+//   <o.2>  DBG_LPDMA2_STOP          <i> LPDMA channel 2 is frozen while CPU is in debug mode
+//   <o.1>  DBG_LPDMA1_STOP          <i> LPDMA channel 1 is frozen while CPU is in debug mode
+//   <o.0>  DBG_LPDMA0_STOP          <i> LPDMA channel 0 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_AHB3_Fz = 0x00000000;
+
+// <h> TPIU Pin Routing
+//   <o0> TRACECLK
+//     <i> ETM Trace Clock
+//       <0x00040002=> Pin PE2
+//       <0x00000008=> Pin PA8
+//   <i> TRACECLK: Pin PE2
+//   <o1> TRACED0
+//     <i> ETM Trace Data 0
+//       <0x00040003=> Pin PE3
+//       <0x00020009=> Pin PC9
+//       <0x00020001=> Pin PC1
+//   <o2> TRACED1
+//     <i> ETM Trace Data 1
+//       <0x0002000A=> Pin PC10
+//       <0x00040004=> Pin PE4
+//   <o3> TRACED2
+//     <i> ETM Trace Data 2
+//       <0x00040005=> Pin PE5
+//       <0x00030002=> Pin PD2
+//   <o4> TRACED3
+//     <i> ETM Trace Data 3
+//       <0x00040006=> Pin PE6
+//       <0x0002000C=> Pin PC12
+// </h>
+TraceClk_Pin = 0x00040002;
+TraceD0_Pin  = 0x00020009;
+TraceD1_Pin  = 0x0002000A;
+TraceD2_Pin  = 0x00040005;
+TraceD3_Pin  = 0x0002000C;
+
+// <h> Flash Download Options
+//   <o.0> Option Byte Loading      <i> Launch the Option Byte Loading after a Flash Download by setting the OBL_LAUNCH bit (causes a reset)
+// </h>
+DoOptionByteLoading = 0x00000000;
+
+// <<< end of configuration section >>>

--- a/Examples/Blinky/.cmsis/Blinky+STM32U575I-EV.dbgconf.base@1.0.0
+++ b/Examples/Blinky/.cmsis/Blinky+STM32U575I-EV.dbgconf.base@1.0.0
@@ -1,0 +1,130 @@
+// File: STM32U535_545_575_585_59x_5Ax.dbgconf
+// Version: 1.0.0
+// Note: refer to STM32U5 reference manual (RM0456)
+//       refer to STM32U535xx datasheet (DS14217)
+//                STM32U545xx datasheet (DS14216)
+//                STM32U575xx datasheet (DS13737)
+//                STM32U585xx datasheet (DS13086)
+//                STM32U59xxx datasheet (DS13633)
+//                STM32U5Axxx datasheet (DS13543)
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Debug MCU configuration register (DBGMCU_CR)
+//   <o.2>  DBG_STANDBY              <i> Debug standby mode
+//   <o.1>  DBG_STOP                 <i> Debug stop mode
+// </h>
+DbgMCU_CR = 0x00000006;
+
+// <h> Debug MCU APB1L freeze register (DBGMCU_APB1LFZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.22> DBG_I2C2_STOP            <i> I2C2 SMBUS timeout is frozen while CPU is in debug mode
+//   <o.21> DBG_I2C1_STOP            <i> I2C1 SMBUS timeout is frozen while CPU is in debug mode
+//   <o.12> DBG_IWDG_STOP            <i> Debug independent watchdog is frozen while CPU is in debug mode
+//   <o.11> DBG_WWDG_STOP            <i> Debug window watchdog is frozen while CPU is in debug mode
+//   <o.5>  DBG_TIM7_STOP            <i> TIM7 is frozen while CPU is in debug mode
+//   <o.4>  DBG_TIM6_STOP            <i> TIM6 is frozen while CPU is in debug mode
+//   <o.3>  DBG_TIM5_STOP            <i> TIM5 is frozen while CPU is in debug mode
+//   <o.2>  DBG_TIM4_STOP            <i> TIM4 is frozen while CPU is in debug mode
+//   <o.1>  DBG_TIM3_STOP            <i> TIM3 is frozen while CPU is in debug mode
+//   <o.0>  DBG_TIM2_STOP            <i> TIM2 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB1L_Fz = 0x00000000;
+
+// <h> Debug MCU APB1H freeze register (DBGMCU_APB1HFZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.7>  DBG_I2C6_STOP            <i> I2C6 is frozen while CPU is in debug mode
+//                                   <i> Reserved on STM32U535/545/575/585 devices
+//   <o.6>  DBG_I2C5_STOP            <i> I2C5 is frozen while CPU is in debug mode
+//                                   <i> Reserved on STM32U535/545/575/585 devices
+//   <o.5>  DBG_LPTIM2_STOP          <i> LPTIM2 is frozen while CPU is in debug mode
+//   <o.1>  DBG_I2C4_STOP            <i> I2C4 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB1H_Fz = 0x00000000;
+
+// <h> Debug MCU APB2 freeze register (DBGMCU_APB2FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.18> DBG_TIM17_STOP           <i> TIM17 is frozen while CPU is in debug mode
+//   <o.17> DBG_TIM16_STOP           <i> TIM16 is frozen while CPU is in debug mode
+//   <o.16> DBG_TIM15_STOP           <i> TIM15 is frozen while CPU is in debug mode
+//   <o.13> DBG_TIM8_STOP            <i> TIM8 is frozen while CPU is in debug mode
+//   <o.11> DBG_TIM1_STOP            <i> TIM1 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB2_Fz = 0x00000000;
+
+// <h> Debug MCU APB3 freeze register (DBGMCU_APB3FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.30> DBG_RTC_STOP             <i> RTC is frozen while CPU is in debug mode.
+//   <o.19> DBG_LPTIM4_STOP          <i> LPTIM4 is frozen while CPU is in debug mode
+//   <o.18> DBG_LPTIM3_STOP          <i> LPTIM3 is frozen while CPU is in debug mode
+//   <o.17> DBG_LPTIM1_STOP          <i> LPTIM1 is frozen while CPU is in debug mode
+//   <o.10> DBG_I2C3_STOP            <i> I2C3 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_APB3_Fz = 0x00000000;
+
+// <h> Debug MCU AHB1 freeze register (DBGMCU_AHB1FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.15> DBG_GPDMA15_STOP         <i> GPDMA channel 15 is frozen while CPU is in debug mode
+//   <o.14> DBG_GPDMA14_STOP         <i> GPDMA channel 14 is frozen while CPU is in debug mode
+//   <o.13> DBG_GPDMA13_STOP         <i> GPDMA channel 13 is frozen while CPU is in debug mode
+//   <o.12> DBG_GPDMA12_STOP         <i> GPDMA channel 12 is frozen while CPU is in debug mode
+//   <o.11> DBG_GPDMA11_STOP         <i> GPDMA channel 11 is frozen while CPU is in debug mode
+//   <o.10> DBG_GPDMA10_STOP         <i> GPDMA channel 10 is frozen while CPU is in debug mode
+//   <o.9>  DBG_GPDMA9_STOP          <i> GPDMA channel 9 is frozen while CPU is in debug mode
+//   <o.8>  DBG_GPDMA8_STOP          <i> GPDMA channel 8 is frozen while CPU is in debug mode
+//   <o.7>  DBG_GPDMA7_STOP          <i> GPDMA channel 7 is frozen while CPU is in debug mode
+//   <o.6>  DBG_GPDMA6_STOP          <i> GPDMA channel 6 is frozen while CPU is in debug mode
+//   <o.5>  DBG_GPDMA5_STOP          <i> GPDMA channel 5 is frozen while CPU is in debug mode
+//   <o.4>  DBG_GPDMA4_STOP          <i> GPDMA channel 4 is frozen while CPU is in debug mode
+//   <o.3>  DBG_GPDMA3_STOP          <i> GPDMA channel 3 is frozen while CPU is in debug mode
+//   <o.2>  DBG_GPDMA2_STOP          <i> GPDMA channel 2 is frozen while CPU is in debug mode
+//   <o.1>  DBG_GPDMA1_STOP          <i> GPDMA channel 1 is frozen while CPU is in debug mode
+//   <o.0>  DBG_GPDMA0_STOP          <i> GPDMA channel 0 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_AHB1_Fz = 0x00000000;
+
+// <h> Debug MCU AHB3 freeze register (DBGMCU_AHB3FZR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.3>  DBG_LPDMA3_STOP          <i> LPDMA channel 3 is frozen while CPU is in debug mode
+//   <o.2>  DBG_LPDMA2_STOP          <i> LPDMA channel 2 is frozen while CPU is in debug mode
+//   <o.1>  DBG_LPDMA1_STOP          <i> LPDMA channel 1 is frozen while CPU is in debug mode
+//   <o.0>  DBG_LPDMA0_STOP          <i> LPDMA channel 0 is frozen while CPU is in debug mode
+// </h>
+DbgMCU_AHB3_Fz = 0x00000000;
+
+// <h> TPIU Pin Routing
+//   <o0> TRACECLK
+//     <i> ETM Trace Clock
+//       <0x00040002=> Pin PE2
+//       <0x00000008=> Pin PA8
+//   <i> TRACECLK: Pin PE2
+//   <o1> TRACED0
+//     <i> ETM Trace Data 0
+//       <0x00040003=> Pin PE3
+//       <0x00020009=> Pin PC9
+//       <0x00020001=> Pin PC1
+//   <o2> TRACED1
+//     <i> ETM Trace Data 1
+//       <0x0002000A=> Pin PC10
+//       <0x00040004=> Pin PE4
+//   <o3> TRACED2
+//     <i> ETM Trace Data 2
+//       <0x00040005=> Pin PE5
+//       <0x00030002=> Pin PD2
+//   <o4> TRACED3
+//     <i> ETM Trace Data 3
+//       <0x00040006=> Pin PE6
+//       <0x0002000C=> Pin PC12
+// </h>
+TraceClk_Pin = 0x00040002;
+TraceD0_Pin  = 0x00020009;
+TraceD1_Pin  = 0x0002000A;
+TraceD2_Pin  = 0x00040005;
+TraceD3_Pin  = 0x0002000C;
+
+// <h> Flash Download Options
+//   <o.0> Option Byte Loading      <i> Launch the Option Byte Loading after a Flash Download by setting the OBL_LAUNCH bit (causes a reset)
+// </h>
+DoOptionByteLoading = 0x00000000;
+
+// <<< end of configuration section >>>

--- a/Examples/Blinky/Blinky.csolution.yml
+++ b/Examples/Blinky/Blinky.csolution.yml
@@ -1,6 +1,6 @@
 # A solution is a collection of related projects that share same base configuration.
 solution:
-  created-for: CMSIS-Toolbox@2.6.0
+  created-for: CMSIS-Toolbox@2.9.0
   cdefault:
 
   # List of tested compilers that can be selected

--- a/Keil.STM32U575I-EV_BSP.pdsc
+++ b/Keil.STM32U575I-EV_BSP.pdsc
@@ -23,7 +23,6 @@
       - add RTE_Components.h files
       - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
       - add Blinky+STM32U575I-EV.dbgconf and Blinky+STM32U575I-EV.dbgconf.base@1.0.0 files for the Blinky example
-      - modified the CI workflows Test-Examples.yml	  
     </release>
   </releases>
 

--- a/Keil.STM32U575I-EV_BSP.pdsc
+++ b/Keil.STM32U575I-EV_BSP.pdsc
@@ -13,7 +13,7 @@
   </licenseSets>
 
   <releases>
-    <release version="1.0.2-dev">
+    <release version="1.0.1-dev">
       Active development ...
       Blinky project:
       - specify thread names using thread attributes
@@ -21,7 +21,6 @@
       - modify app_main_thread (replace loop forever)
       - add DWARF-5 debug information
       - add RTE_Components.h files
-      - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
       - add Blinky+STM32U575I-EV.dbgconf and Blinky+STM32U575I-EV.dbgconf.base@1.0.0 files for the Blinky example
     </release>
   </releases>

--- a/Keil.STM32U575I-EV_BSP.pdsc
+++ b/Keil.STM32U575I-EV_BSP.pdsc
@@ -13,7 +13,7 @@
   </licenseSets>
 
   <releases>
-    <release version="1.0.1-dev">
+    <release version="1.0.2-dev">
       Active development ...
       Blinky project:
       - specify thread names using thread attributes
@@ -21,6 +21,9 @@
       - modify app_main_thread (replace loop forever)
       - add DWARF-5 debug information
       - add RTE_Components.h files
+      - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
+      - add Blinky+STM32U575I-EV.dbgconf and Blinky+STM32U575I-EV.dbgconf.base@1.0.0 files for the Blinky example
+      - modified the CI workflows Test-Examples.yml	  
     </release>
   </releases>
 


### PR DESCRIPTION
- Updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0. 
- Add Blinky+STM32U575I-EV.dbgconf and Blinky+STM32U575I-EV.dbgconf.base@1.0.0 files for the Blinky example. 
- Modified the CI workflows Test-Examples.yml. 
- Updated release section in Keil.STM32U575I-EV_BSP.pdsc.